### PR TITLE
Add package build and publish workflow for dockerfile-dotnet9

### DIFF
--- a/.github/workflows/publish-docker-image-dotnet9.yml
+++ b/.github/workflows/publish-docker-image-dotnet9.yml
@@ -1,0 +1,51 @@
+name: Docker Image CI - dotnet9
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+      
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@master
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.PUBLISH_ACTIONS }}
+      
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@master
+        with:
+          context: .
+          file: dockerfile-dotnet9
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ env.IMAGE_NAME }}-dotnet9:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This adds a github action to publish a package for dockerfile-dotnet9 to allow using cncnet directly

Note: This action needs the necessary permissions to publish a package to your registry

To add perms:
1. Profile -> Settings -> Developer Settings -> Personal access tokens -> Tokens (classic)
2. Generate new token (classic)
3. write:packages
4. Copy the token
5. Click your repo (https://github.com/CnCNet/cncnet-docker-dotnetcore-tunnel)
6. Settings (top)
7. Secrets and variables -> Actions
8. New repository secret
9. Name `PUBLISH_ACTIONS`
10. Paste token from PAT

Please let me know if you need anything at all!

I've been using your repo for some time and thought I'd try to contribute and make using cncnet a bit easier/more automated