### PR TITLE
Use weekly cron schedule for docker image publish workflows

### DIFF
--- a/.github/workflows/publish-docker-image-dotnet10.yml
+++ b/.github/workflows/publish-docker-image-dotnet10.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    # Runs at 00:00 every Monday (0 = Sunday, 1 = Monday)
+    - cron: '0 0 * * 1'
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/publish-docker-image-dotnet8.yml
+++ b/.github/workflows/publish-docker-image-dotnet8.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    # Runs at 00:00 every Monday (0 = Sunday, 1 = Monday)
+    - cron: '0 0 * * 1'
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/publish-docker-image-dotnet9.yml
+++ b/.github/workflows/publish-docker-image-dotnet9.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    # Runs at 00:00 every Monday (0 = Sunday, 1 = Monday)
+    - cron: '0 0 * * 1'
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
Update image publish workflows to run weekly to include changes to upstream github repo referenced in dockerfiles